### PR TITLE
Redirect if no vaultAddress is found

### DIFF
--- a/src/pages/Vault/Vault.tsx
+++ b/src/pages/Vault/Vault.tsx
@@ -85,6 +85,7 @@ import {
 import SPAAnchor from '../../components/SPAAnchor/SPAAnchor';
 import { buildHref } from '../../utils/routes';
 import ROUTES from '../../constants/routes';
+import { navigateTo } from 'utils/routes';
 
 type VaultProps = RouteComponentProps<{
     vaultId: string;
@@ -109,8 +110,14 @@ const Vault: React.FC<VaultProps> = (props) => {
     const [lastValidUserVaultData, setLastValidUserVaultData] = useState<UserVaultData | undefined>(undefined);
 
     const { params } = props.match;
-    const vaultId = params && params.vaultId ? params.vaultId : '';
-    const vaultAddress = !!VAULT_MAP[vaultId] ? VAULT_MAP[vaultId].addresses[networkId] : undefined;
+    const vaultId = params && params.vaultId && !!VAULT_MAP[params.vaultId] ? params.vaultId : '';
+    const vaultAddress = !!vaultId ? VAULT_MAP[vaultId].addresses[networkId] : undefined;
+
+    useEffect(() => {
+        if (!vaultAddress) {
+            navigateTo(ROUTES.Options.Vaults);
+        }
+    }, []);
 
     const paymentTokenBalanceQuery = useStableBalanceQuery(walletAddress, networkId, {
         enabled: isAppReady && isWalletConnected,


### PR DESCRIPTION
If no vaultId is set in URL parameters or if vaultAddress is not found with this vaultId, redirect to vaults list page

Examples :
- https://thalesmarket.io/vaults/discount-vault => OK
- https://thalesmarket.io/vaults/discount-test => KO, redirect to vaults list